### PR TITLE
Fix route creation existing file check and success message

### DIFF
--- a/meteor-boilerplate
+++ b/meteor-boilerplate
@@ -67,7 +67,8 @@ case ${1} in
         # Create file
         createFile route.js client/routes/${2}Route.js $2 $3
         # Succesful
-        echo "Successfully created route \"${2^}Route\" with the path ${3}"
+	routeName="$(tr '[:lower:]' '[:upper:]' <<< ${2:0:1})${2:1}"
+        echo "Successfully created route \"${routeName}Route\" with the path ${3}"
         ;;
     create:module)
         if [ -z ${2} ]; then echo "Define a module name!"; exit; fi


### PR DESCRIPTION
Just a couple little fixes to the route creation script. Right now the existing route check never actually fails and the success message always says _'Successfully created route "Route"...'_. Both are due to the incorrect variable `${h2}`.

(Also my first GitHub pull request, happy it could be on such a handy repo!)
